### PR TITLE
Add unit tests for scoring and ignore parsing

### DIFF
--- a/cmd/quickdup/filter.go
+++ b/cmd/quickdup/filter.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
+	"strings"
 	"sync"
 )
 
@@ -138,21 +140,37 @@ func LoadIgnoredHashes(dir string, strategyName string) map[uint64]bool {
 				os.WriteFile(ignorePath, jsonData, 0644)
 			}
 		}
-		return nil
+		return map[uint64]bool{}
 	}
 
 	var ignoreFile IgnoreFile
 	if err := json.Unmarshal(data, &ignoreFile); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not parse %s: %v\n", ignorePath, err)
-		return nil
+		return map[uint64]bool{}
 	}
 
 	ignored := make(map[uint64]bool)
 	for _, hashStr := range ignoreFile.Ignored {
-		var hash uint64
-		if _, err := fmt.Sscanf(hashStr, "%x", &hash); err == nil {
+		if hash, ok := parseIgnoredHash(hashStr); ok {
 			ignored[hash] = true
 		}
 	}
 	return ignored
+}
+
+func parseIgnoredHash(hashStr string) (uint64, bool) {
+	s := strings.TrimSpace(hashStr)
+	s = strings.TrimPrefix(s, "[")
+	s = strings.TrimSuffix(s, "]")
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(strings.ToLower(s), "0x")
+	if s == "" {
+		return 0, false
+	}
+
+	hash, err := strconv.ParseUint(s, 16, 64)
+	if err != nil {
+		return 0, false
+	}
+	return hash, true
 }

--- a/cmd/quickdup/filter_test.go
+++ b/cmd/quickdup/filter_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadIgnoredHashes_CreatesFileWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	strategyName := "word-indent"
+
+	ignored := LoadIgnoredHashes(dir, strategyName)
+	if ignored == nil {
+		t.Fatalf("expected non-nil map")
+	}
+
+	ignorePath := filepath.Join(dir, ".quickdup", strategyName+"-ignore.json")
+	if _, err := os.Stat(ignorePath); err != nil {
+		t.Fatalf("expected ignore file to exist at %s: %v", ignorePath, err)
+	}
+}
+
+func TestLoadIgnoredHashes_ParsesHexVariants(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	strategyName := "word-indent"
+	ignorePath := filepath.Join(dir, ".quickdup", strategyName+"-ignore.json")
+	if err := os.MkdirAll(filepath.Dir(ignorePath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	data := []byte(`{
+  "description": "Patterns to ignore",
+  "ignored": [
+    "56c2f5f9b27ed5a0",
+    "[c32ca0ee344f8e23]",
+    "0x0123456789abcdef",
+    "not-hex",
+    "",
+    "   [0x000000000000000f]   "
+  ]
+}`)
+	if err := os.WriteFile(ignorePath, data, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	ignored := LoadIgnoredHashes(dir, strategyName)
+
+	want := []uint64{
+		0x56c2f5f9b27ed5a0,
+		0xc32ca0ee344f8e23,
+		0x0123456789abcdef,
+		0x000000000000000f,
+	}
+	for _, h := range want {
+		if !ignored[h] {
+			t.Fatalf("expected hash %016x to be ignored", h)
+		}
+	}
+}
+
+func TestParseIgnoredHash(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   string
+		want uint64
+		ok   bool
+	}{
+		{"56c2f5f9b27ed5a0", 0x56c2f5f9b27ed5a0, true},
+		{"[56c2f5f9b27ed5a0]", 0x56c2f5f9b27ed5a0, true},
+		{"0x56c2f5f9b27ed5a0", 0x56c2f5f9b27ed5a0, true},
+		{"[0x56c2f5f9b27ed5a0]", 0x56c2f5f9b27ed5a0, true},
+		{"   [0x56c2f5f9b27ed5a0]   ", 0x56c2f5f9b27ed5a0, true},
+		{"", 0, false},
+		{"[]", 0, false},
+		{"not-hex", 0, false},
+	}
+
+	for _, tc := range cases {
+		got, ok := parseIgnoredHash(tc.in)
+		if ok != tc.ok || got != tc.want {
+			t.Fatalf("parseIgnoredHash(%q) = (%x, %v), want (%x, %v)", tc.in, got, ok, tc.want, tc.ok)
+		}
+	}
+}

--- a/cmd/quickdup/strategy_score_test.go
+++ b/cmd/quickdup/strategy_score_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestWordOnlyStrategy_Score_SimilarityScaling(t *testing.T) {
+	t.Parallel()
+
+	s := &WordOnlyStrategy{}
+
+	entries := make([]Entry, 80)
+	for i := range entries {
+		entries[i] = NewWordOnlyEntry(fmt.Sprintf("w%d", i))
+	}
+
+	// adjustedSim = similarity*2 - 1
+	// simFactor = adjustedSim^3
+	// score = int(uniqueWords*simFactor) + len(entries)/20
+	if got := s.Score(entries, 1.0); got != 84 { // 80*1 + 4
+		t.Fatalf("score at 1.0 = %d, want 84", got)
+	}
+	if got := s.Score(entries, 0.75); got != 14 { // 80*0.125 + 4
+		t.Fatalf("score at 0.75 = %d, want 14", got)
+	}
+	if got := s.Score(entries, 0.5); got != 4 { // 80*0 + 4
+		t.Fatalf("score at 0.5 = %d, want 4", got)
+	}
+}
+
+func TestWordIndentStrategy_Score_ImbalancePenalty(t *testing.T) {
+	t.Parallel()
+
+	s := &WordIndentStrategy{}
+
+	balanced := []Entry{
+		NewWordIndentEntry(4, "a"),
+		NewWordIndentEntry(0, "b"),
+		NewWordIndentEntry(-4, "c"),
+	}
+	if got := s.Score(balanced, 1.0); got != 3 {
+		t.Fatalf("balanced score = %d, want 3", got)
+	}
+
+	unbalanced := []Entry{
+		NewWordIndentEntry(4, "a"),
+		NewWordIndentEntry(0, "b"),
+		NewWordIndentEntry(0, "c"),
+	}
+	if got := s.Score(unbalanced, 1.0); got != 0 {
+		t.Fatalf("unbalanced score = %d, want 0", got)
+	}
+}
+
+func TestNormalizedIndentStrategy_Score_ImbalancePenalty(t *testing.T) {
+	t.Parallel()
+
+	s := &NormalizedIndentStrategy{}
+
+	balanced := []Entry{
+		NewNormalizedIndentEntry(1, "a"),
+		NewNormalizedIndentEntry(0, "b"),
+		NewNormalizedIndentEntry(-1, "c"),
+	}
+	if got := s.Score(balanced, 1.0); got != 3 {
+		t.Fatalf("balanced score = %d, want 3", got)
+	}
+
+	unbalanced := []Entry{
+		NewNormalizedIndentEntry(1, "a"),
+		NewNormalizedIndentEntry(0, "b"),
+		NewNormalizedIndentEntry(0, "c"),
+	}
+	if got := s.Score(unbalanced, 1.0); got != 2 {
+		t.Fatalf("unbalanced score = %d, want 2", got)
+	}
+}
+
+func TestInlineableStrategy_Score_MatchesOnlyInlineableShapes(t *testing.T) {
+	t.Parallel()
+
+	s := &InlineableStrategy{}
+
+	inlineable := []Entry{
+		&InlineableEntry{Word: "public"},
+		&InlineableEntry{Word: "{"},
+		&InlineableEntry{Word: "return"},
+		&InlineableEntry{Word: "}"},
+	}
+	if got := s.Score(inlineable, 1.0); got != 100 {
+		t.Fatalf("inlineable score = %d, want 100", got)
+	}
+
+	notInlineable := []Entry{
+		&InlineableEntry{Word: "public"},
+		&InlineableEntry{Word: "if"},
+		&InlineableEntry{Word: "return"},
+		&InlineableEntry{Word: "}"},
+	}
+	if got := s.Score(notInlineable, 1.0); got != 0 {
+		t.Fatalf("non-inlineable score = %d, want 0", got)
+	}
+}


### PR DESCRIPTION
Adds table-driven unit tests for strategy scoring and ignore hash parsing/creation.

Also makes ignore parsing robust to common copy-paste formats from CLI output (e.g. "[deadbeef...]" and "0xdeadbeef...").

Closes #2.